### PR TITLE
ci: Skip fragment check for Zulip client-side routing links

### DIFF
--- a/.github/workflows/links.yml
+++ b/.github/workflows/links.yml
@@ -33,6 +33,9 @@ jobs:
           fail: true
           # Accept the HTTP status code 429 (Too Many Requests) to avoid failing the workflow
           # when the rate limit is exceeded.
+          # lychee strictly validates fragments; Zulip fragments are JS-routed and lack HTML anchors,
+          # which leads to false failures. Strip Zulip fragments and check the base URL instead.
+          # See lychee issues: https://github.com/lycheeverse/lychee/issues/1791
           args: |
             --no-progress
             --include-fragments


### PR DESCRIPTION
ci error: https://github.com/rust-lang/crates-io-auth-action/actions/runs/18473910894/job/52633960065

 After upgrading lychee-action to v2.5.0 (which uses lychee 0.19.1),
  the fragment checking now correctly validates URL fragments. However,
  Zulip uses client-side routing where fragments like `#narrow/channel/...`
  are handled by JavaScript and don't exist as HTML anchors in the
  server response.

  Use the `--remap` flag to strip fragments from Zulip URLs while still
  checking that the base URL is reachable. This allows fragment checking
  to remain enabled for other links in the repository.

  Related: lycheeverse/lychee#1675
  Related: lycheeverse/lychee#1791