### PR TITLE
Update Renovate GitHub Action digest pinning configuration

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -3,7 +3,7 @@
     extends: [
         "config:recommended",
         ":maintainLockFilesMonthly",
-        "helpers:pinGitHubActionDigests",
+        "helpers:pinGitHubActionDigestsToSemver",
     ],
     automerge: true,
     packageRules: [


### PR DESCRIPTION
As discussed in [#t-infra > How to pin github actions in renovate](https://rust-lang.zulipchat.com/#narrow/channel/242791-t-infra/topic/How.20to.20pin.20github.20actions.20in.20renovate/with/579906011)