### PR TITLE
renovate: don't raise individual PRs for crates non breaking changes

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -8,16 +8,9 @@
     automerge: true,
     packageRules: [
         {
-            matchCategories: ["javascript", "typescript"],
-            matchUpdateTypes: ["patch"],
-            // Disable patch updates for single dependencies because patches
-            // are updated periodically with lockfile maintainance.
-            enabled: false,
-        },
-        {
-            matchCategories: ["rust"],
-            matchUpdateTypes: ["patch"],
-            // Disable patch updates for single dependencies because patches
+            matchCategories: ["rust", "javascript", "typescript"],
+            matchJsonata: ["isBreaking != true"],
+            // Disable non-breaking change updates because they
             // are updated periodically with lockfile maintainance.
             enabled: false,
         },


### PR DESCRIPTION
Before this PR, we were receiving PRs when crate `1.2.3` was updated to `1.3.0`.
With this PR, we should receive PRs only when `2.0.0` is out.